### PR TITLE
Reexport serialport::Error.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub use serialport::{// Traits
                      SerialPort,
 
                      // Structs
+                     Error,
                      SerialPortInfo,
                      SerialPortSettings,
 


### PR DESCRIPTION
This allows error handling without importing  `serialport` crate.