### PR TITLE
docs: Example improvements - handle WouldBlock correctly, typo

### DIFF
--- a/examples/serial_printline.rs
+++ b/examples/serial_printline.rs
@@ -76,7 +76,7 @@ pub fn main() {
                     }
                     if ready.is_readable() {
                         // With edge triggered events, we must perform reading until we receive a WouldBlock.
-                        // See https://docs.rs/mio/0.6.16/mio/struct.Poll.html for details.
+                        // See https://docs.rs/mio/0.6/mio/struct.Poll.html for details.
                         loop {
                             match rx.read(&mut rx_buf) {
                                 Ok(count) => {


### PR DESCRIPTION
Fixes #12 

I didn't actually try it out, it fails to compile with

```rust
error[E0046]: not all trait items implemented, missing: `bytes_to_read`, `bytes_to_write`, `clear`
   --> src/unix.rs:134:1
    |
134 | impl SerialPort for Serial {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `bytes_to_read`, `bytes_to_write`, `clear` in implementation
    |
    = note: `bytes_to_read` from trait: `fn(&Self) -> std::result::Result<u32, serialport::Error>`
    = note: `bytes_to_write` from trait: `fn(&Self) -> std::result::Result<u32, serialport::Error>`
    = note: `clear` from trait: `fn(&Self, serialport::ClearBuffer) -> std::result::Result<(), serialport::Error>`
```

But that's not due to something I did, so I hope I just got the example right :-/