### PR TITLE
Fix feature flag to not mandatory require libudev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ libudev = ["serialport/libudev"]
 
 [dependencies]
 mio = "0.6"
-serialport = "~3.1"
+serialport = { version = "~3.1", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.11"


### PR DESCRIPTION
Before, the serialport/default feature wasn't turned off even if the default
feature of the mio-serial was off. We need to deselect the serialport/default
explicitly, and turn it on by the default of the mio-serial.