### PR TITLE
retry syscalls on Interrupted/EINTR result

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -393,9 +393,20 @@ impl SerialPort for Serial {
     }
 }
 
+macro_rules! uninterruptibly {
+    ($e:expr) => {{
+        loop {
+            match $e {
+                Err(ref error) if error.kind() == io::ErrorKind::Interrupted => {}
+                res => break res,
+            }
+        }
+    }};
+}
+
 impl Read for Serial {
     fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
-        match unsafe {
+        uninterruptibly!(match unsafe {
             libc::read(
                 self.as_raw_fd(),
                 bytes.as_ptr() as *mut libc::c_void,
@@ -404,13 +415,13 @@ impl Read for Serial {
         } {
             x if x >= 0 => Ok(x as usize),
             _ => Err(io::Error::last_os_error()),
-        }
+        })
     }
 }
 
 impl Write for Serial {
     fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-        match unsafe {
+        uninterruptibly!(match unsafe {
             libc::write(
                 self.as_raw_fd(),
                 bytes.as_ptr() as *const libc::c_void,
@@ -419,19 +430,22 @@ impl Write for Serial {
         } {
             x if x >= 0 => Ok(x as usize),
             _ => Err(io::Error::last_os_error()),
-        }
+        })
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        termios::tcdrain(self.inner.as_raw_fd())
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))
-        //self.inner.flush()
+        uninterruptibly!(
+            termios::tcdrain(self.inner.as_raw_fd()).map_err(|error| match error {
+                nix::Error::Sys(errno) => io::Error::from(errno),
+                error => io::Error::new(io::ErrorKind::Other, error.to_string()),
+            })
+        )
     }
 }
 
 impl<'a> Read for &'a Serial {
     fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
-        match unsafe {
+        uninterruptibly!(match unsafe {
             libc::read(
                 self.as_raw_fd(),
                 bytes.as_ptr() as *mut libc::c_void,
@@ -440,13 +454,13 @@ impl<'a> Read for &'a Serial {
         } {
             x if x >= 0 => Ok(x as usize),
             _ => Err(io::Error::last_os_error()),
-        }
+        })
     }
 }
 
 impl<'a> Write for &'a Serial {
     fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-        match unsafe {
+        uninterruptibly!(match unsafe {
             libc::write(
                 self.as_raw_fd(),
                 bytes.as_ptr() as *const libc::c_void,
@@ -455,12 +469,16 @@ impl<'a> Write for &'a Serial {
         } {
             x if x >= 0 => Ok(x as usize),
             _ => Err(io::Error::last_os_error()),
-        }
+        })
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        termios::tcdrain(self.inner.as_raw_fd())
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))
+        uninterruptibly!(
+            termios::tcdrain(self.inner.as_raw_fd()).map_err(|error| match error {
+                nix::Error::Sys(errno) => io::Error::from(errno),
+                error => io::Error::new(io::ErrorKind::Other, error.to_string()),
+            })
+        )
     }
 }
 


### PR DESCRIPTION
The flush syscall can return an io::Error::Interrupted / EINTR result, indicating that the syscall should be retried immediately. I've wrapped all syscalls with a macro (which I took from tokio-io) that will retry the syscall if the result is an io::Error::Interrupted.

I had issues in a setup with a serial device where I can put the device into listen mode and it might return a message, or I can stop the listen mode and send a command to the device. The code is something like:

```rust
loop {
  io.write("start listen mode").await;
  io.read().await; // device returns "ok"
  tokio::select! {
    message = io.read() => {}
    message = stream.next() => {
      io.write("stop listen mode").await;
      io.write(message.to_io_command_str()).await;
      let result = io.read().await;
    }
  }
}
```

When sending the stop listen mode string, the device returns "ok", which is captured by the pending io.read() from the first branch most of the time, but sometimes (when the stream has multiple messages available) the write seems to race with an underlying flush syscall from the pending read, causing the write call to return a Custom { Other { description: "EINTR: Interrupted syscall" } }.

I think the tokio Sink implementation usually handles Interrupted errors by retrying but it fails to do so here because the Serial errors are transformed into io::Error::Custom