### PR TITLE
Re export `SerialPortType` and `UsbPortInfo` from `serialport-rs`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,9 @@ pub use serialport::{
     SerialPort,
     SerialPortBuilder,
     SerialPortInfo,
+    SerialPortType,
     StopBits,
+    UsbPortInfo,
 };
 
 // Re-export port-enumerating utility function.


### PR DESCRIPTION
This PR re-exports some types to allow the user to use the `port_type` field of `SerialPortInfo`