### PR TITLE
bumbed nix version to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ default-features = false
 version = "0.4"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.23"
+nix = "0.24"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["commapi", "handleapi", "winbase"] }


### PR DESCRIPTION
Currently serialport-rs uses [nix version 0.24](https://github.com/serialport/serialport-rs/blob/6542d11235532ec78332e1e6b4986e73b8d55b11/Cargo.toml#L20). It would be nice if this library did not have to build 2 versions of nix.
The code builds and I don't expect this change to be breaking, but I was unable to test the changes.