### PR TITLE
Upgrade nix to 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ default-features = false
 version = "0.4"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.24"
+nix = "0.25"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["commapi", "handleapi", "winbase"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ impl SerialStream {
     /// * `Io` for any error while setting exclusivity for the port.
     #[cfg(unix)]
     pub fn set_exclusive(&mut self, exclusive: bool) -> crate::Result<()> {
-        self.inner.set_exclusive(exclusive).map_err(|e| e)
+        self.inner.set_exclusive(exclusive)
     }
 
     /// Returns the exclusivity of the port


### PR DESCRIPTION
Upgrade to the latest [nix](https://github.com/nix-rust/nix) version [0.25](https://github.com/nix-rust/nix/releases/tag/v0.25.0).

I've opened a similar PR for serialport: https://github.com/serialport/serialport-rs/pull/67.
Therefore we should update our serialport version here as soon as serialport merges and releases the nix update to avoid multiple nix versions in projects using mio-serial.