### PR TITLE
Fix MSRV & Windows clippy warning

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -12,7 +12,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.56.1
+          - 1.60.0
           # - nightly
     env:
       TEST_PORT_A: /tmp/ttyS10
@@ -43,7 +43,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.56.1
+          - 1.60.0
           # - nightly
     env:
       TEST_PORT_A: /tmp/ttyS10
@@ -81,7 +81,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.56.1
+          - 1.60.0
           # - nightly
     env:
       TEST_PORT_A: COM10

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -12,7 +12,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.46.0
+          - 1.56.1
           # - nightly
     env:
       TEST_PORT_A: /tmp/ttyS10
@@ -43,7 +43,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.46.0
+          - 1.56.1
           # - nightly
     env:
       TEST_PORT_A: /tmp/ttyS10
@@ -81,7 +81,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.46.0
+          - 1.56.1
           # - nightly
     env:
       TEST_PORT_A: COM10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous", "hardware-support"]
 edition = "2018"
 
 [package.metadata]
-msrv = "1.46.0" # Used by cargo-msrv
+msrv = "1.56.1" # Used by cargo-msrv
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous", "hardware-support"]
 edition = "2018"
 
 [package.metadata]
-msrv = "1.56.1" # Used by cargo-msrv
+msrv = "1.60.0" # Used by cargo-msrv
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cargo build --no-default-features
 ```
 
 ### MSRV
-The Minimum Supported Rust Version is **1.46.0** as found using [cargo-msrv](https://crates.io/crates/cargo-msrv)
+The Minimum Supported Rust Version is **1.56.1** as found using [cargo-msrv](https://crates.io/crates/cargo-msrv)
 
 ## Examples
 A few examples can be found [here](https://github.com/berkowski/mio-serial/tree/master/examples).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cargo build --no-default-features
 ```
 
 ### MSRV
-The Minimum Supported Rust Version is **1.56.1** as found using [cargo-msrv](https://crates.io/crates/cargo-msrv)
+The Minimum Supported Rust Version is **1.60.0** as found using [cargo-msrv](https://crates.io/crates/cargo-msrv)
 
 ## Examples
 A few examples can be found [here](https://github.com/berkowski/mio-serial/tree/master/examples).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,7 +602,6 @@ impl TryFrom<NativeBlockingSerialPort> for SerialStream {
             log::error!("unable to open new async file handle");
             return Err(crate::Error::from(StdIoError::last_os_error()));
         }
-        let handle = unsafe { mem::transmute(handle) };
 
         // Construct NamedPipe and COMPort from Handle
         //


### PR DESCRIPTION
This PR updates all dependencies to their latest version. Namely this is:

- nix: 0.25 => 0.26
- env_logger: 0.9 => 0.10

Furthermore bump the MSRV to 1.60.0 as this is required by env_logger v0.10.0 (see https://github.com/rust-cli/env_logger/commit/660cf7feb27e07bd308c3952637c5ae21c438846).