### PR TITLE
Setting VMIN on a non-cooked port has no effect

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,14 +85,6 @@ pub struct SerialStream {
     pipe: NamedPipe,
 }
 
-#[cfg(unix)]
-fn map_nix_error(e: nix::Error) -> crate::Error {
-    crate::Error {
-        kind: crate::ErrorKind::Io(StdIoErrorKind::Other),
-        description: e.to_string(),
-    }
-}
-
 impl SerialStream {
     /// Open a nonblocking serial port from the provided builder
     ///
@@ -537,20 +529,11 @@ impl TryFrom<NativeBlockingSerialPort> for SerialStream {
     type Error = crate::Error;
     #[cfg(unix)]
     fn try_from(port: NativeBlockingSerialPort) -> std::result::Result<Self, Self::Error> {
+        // Set the O_NONBLOCK flag.
         log::debug!(
-            "switching {} to asynchronous mode",
+            "setting O_NONBLOCK for {}",
             port.name().unwrap_or_else(|| String::from("<UNKNOWN>"))
         );
-        log::debug!("setting VMIN = 1");
-        use nix::sys::termios::{self, SetArg, SpecialCharacterIndices};
-        let mut t = termios::tcgetattr(port.as_raw_fd()).map_err(map_nix_error)?;
-
-        // Set VMIN = 1 to block until at least one character is received.
-        t.control_chars[SpecialCharacterIndices::VMIN as usize] = 1;
-        termios::tcsetattr(port.as_raw_fd(), SetArg::TCSANOW, &t).map_err(map_nix_error)?;
-
-        // Set the O_NONBLOCK flag.
-        log::debug!("setting O_NONBLOCK flag");
         let flags = unsafe { libc::fcntl(port.as_raw_fd(), libc::F_GETFL) };
         if flags < 0 {
             return Err(StdIoError::last_os_error().into());


### PR DESCRIPTION
You must be in [non-canonical mode](https://www.gnu.org/software/libc/manual/html_node/Noncanonical-Input.html) and without setting O_NONBLOCK.

References:
 - https://stackoverflow.com/questions/20154157/termios-vmin-vtime-and-blocking-non-blocking-read-operations
 - http://unixwiz.net/techtips/termios-vmin-vtime.html