### PR TITLE
Set Windows timeouts to enforce non-blocking read

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -803,17 +803,18 @@ mod sys {
 #[cfg(windows)]
 mod sys {
 
+    use winapi::um::winnt::MAXDWORD;
+
     use super::os_prelude::*;
     use super::StdIoResult;
     /// Overrides timeout value set by serialport-rs so that the read end will
     /// never wake up with 0-byte payload.
     pub(crate) fn override_comm_timeouts(handle: RawHandle) -> StdIoResult<()> {
         let mut timeouts = COMMTIMEOUTS {
-            // wait at most 1ms between two bytes (0 means no timeout)
-            ReadIntervalTimeout: 1,
-            // disable "total" timeout to wait at least 1 byte forever
-            ReadTotalTimeoutMultiplier: 0,
-            ReadTotalTimeoutConstant: 0,
+            // Enable POSIX-like behaviour to wait for ANY about of bytes or timeout
+            ReadIntervalTimeout: MAXDWORD,
+            ReadTotalTimeoutMultiplier: MAXDWORD,
+            ReadTotalTimeoutConstant: 1,
             // write timeouts are just copied from serialport-rs
             WriteTotalTimeoutMultiplier: 0,
             WriteTotalTimeoutConstant: 0,


### PR DESCRIPTION
This is the equivalent of the PR https://github.com/serialport/serialport-rs/pull/79. I would actually recommend completely removing the COMMTIMEOUTS override in mio-serial when/if the patch is accepted on serialport-rs, as this will solve the issue of read not returning available data until buffer is full or timeout. However, without this patch, the fix in serialport-rs does nothing.

This behavior is critical for and request/response protocol. I see 27-30 millisecond _minimum_ latency on reads for data that takes <1ms to transfer, which is unacceptable.


Original change description:

Settings ReadIntervalTimeout and ReadTotalTimeoutMultiplier to MAXDWORD in the COMMTIMEOUTS structure on Windows makes Windows behave as normally expected; a read call to the serial port will return immediately if there is any data available, or if a single byte arrives in the buffer. If no data arrives, it will timeout out after the timeout specified in ReadTotalTimeoutConstant.

This fixes issues where reading from a serial port would take longer than desired when less data arrives that there is room for in the buffer passed to the read function.

See also: https://learn.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-commtimeouts